### PR TITLE
Change API version V1beta => V1 and add comment for vpcid and CVE fix

### DIFF
--- a/cmd/sfs-provisioner/Dockerfile
+++ b/cmd/sfs-provisioner/Dockerfile
@@ -1,5 +1,5 @@
 # Based on centos
-FROM centos:7.4.1708
+FROM centos:7.6.1810
 LABEL maintainers="Kubernetes Authors"
 LABEL description="SFS Provisioner"
 

--- a/deploy/sfs-provisioner/kubernetes/statefulset.yaml
+++ b/deploy/sfs-provisioner/kubernetes/statefulset.yaml
@@ -44,12 +44,17 @@ roleRef:
 ---
 
 kind: StatefulSet
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 metadata:
   name: sfs-provisioner
 spec:
-  serviceName: "sfs-provisioner"
+  podManagementPolicy: OrderedReady
   replicas: 1
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      app: sfs-provisioner
+  serviceName: sfs-provisioner
   template:
     metadata:
       labels:
@@ -66,6 +71,7 @@ spec:
           image: quay.io/huaweicloud/sfs-provisioner:latest
           imagePullPolicy: Always
           args:
+          # - "--vpcid=YOUR_VPCID mandatory if you have multiple VPCID"
             - "--v=5"
             - "--cloudconfig=$(CLOUD_CONFIG)"
           env:

--- a/examples/sfs-provisioner/kubernetes/sc.yaml
+++ b/examples/sfs-provisioner/kubernetes/sc.yaml
@@ -1,7 +1,8 @@
-apiVersion: storage.k8s.io/v1beta1
+apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
   name: sfs-storage-class
 provisioner: external.k8s.io/sfs
+reclaimPolicy: Delete
 parameters:
   protocol: NFS


### PR DESCRIPTION
**What this PR does / why we need it**:
It upgrade the api version and add comment for vpcid as this option is mandatory when tenant has multiple vpc (in this case autodetect vpcid doesn't work).
Also upgrade base docker centos image to evict CVE
![image](https://user-images.githubusercontent.com/23224162/54610759-ec618380-4a55-11e9-9c7f-a15d4744305a.png)

see https://github.com/huaweicloud/external-sfs/issues/22