### PR TITLE
Add a sleep as a workaround of too many API calls

### DIFF
--- a/pkg/sfs/share.go
+++ b/pkg/sfs/share.go
@@ -19,6 +19,7 @@ package sfs
 import (
 	"fmt"
 	"strconv"
+	"time"
 
 	"github.com/golang/glog"
 	"github.com/huaweicloud/golangsdk"
@@ -75,6 +76,8 @@ func CreateShare(client *golangsdk.ServiceClient, volOptions *controller.VolumeO
 // WaitForShareStatus wait for share desired status until timeout
 func WaitForShareStatus(client *golangsdk.ServiceClient, shareID string, desiredStatus string, timeout int) error {
 	return golangsdk.WaitFor(timeout, func() (bool, error) {
+		// reduce the amount of API calls
+		time.Sleep(2 * time.Second)
 		share, err := GetShare(client, shareID)
 		if err != nil {
 			return false, err


### PR DESCRIPTION
This adds a 2s sleep to waitStatus process to reduce the amount of
API calls.

<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```

